### PR TITLE
Remember count for widget click event

### DIFF
--- a/widgets/counter.js
+++ b/widgets/counter.js
@@ -1,0 +1,83 @@
+const COUNTER_STORAGE = 'counter-db';
+const COUNTER_KEY = 'counter';
+const COUNTER_NAME = 'widget-clicks';
+const COUNT_VALUE = 'count';
+let db = null;
+
+const openDatabase = async () => {
+  if (db) {
+    return Promise.resolve();
+  }
+  // Let us open our training sample database.
+  const DBOpenRequest = indexedDB.open(COUNTER_STORAGE);
+
+  return new Promise((resolve, reject) => {
+    // Register two event handlers to act on the database being opened successfully, or not.
+    DBOpenRequest.onerror = () => {
+      reject(new Error('Error loading database.'));
+    };
+
+    DBOpenRequest.onupgradeneeded = () => {
+      const db = DBOpenRequest.result;
+      db.createObjectStore(COUNTER_STORAGE, { keyPath: COUNTER_KEY });
+    };
+
+    DBOpenRequest.onsuccess = () => {
+      db = DBOpenRequest.result;
+      resolve();
+    };
+  });
+};
+
+const getObjectStore = async () => {
+  await openDatabase();
+  // open a read/write db transaction
+  const transaction = db.transaction([COUNTER_STORAGE], 'readwrite');
+
+  // report on the error of opening the transaction
+  transaction.onerror = (event) => {
+    console.error('Transaction failed', event);
+  }
+
+  // create an object store on the transaction
+  return transaction.objectStore(COUNTER_STORAGE);
+};
+
+const getCount = async () => {
+  const objectStore = await getObjectStore();
+  return new Promise((resolve, reject) => {
+    const objectStoreRequest = objectStore.get(COUNTER_NAME);
+    objectStoreRequest.onerror = (event) => {
+      // report the error of the request
+      console.error('Object Store Request failed', event);
+      reject();
+    };
+
+    objectStoreRequest.onsuccess = () => {
+      const { result } = objectStoreRequest;
+      resolve(result ? result[COUNT_VALUE] : 0);
+    };
+  });
+};
+
+const incrementCount = async (count) => {
+  const objectStore = await getObjectStore();
+  return new Promise((resolve, reject) => {
+    const objectStoreRequest = objectStore.put({ [COUNTER_KEY]: COUNTER_NAME, [COUNT_VALUE]: count + 1 });
+    objectStoreRequest.onerror = (event) => {
+      // report the error of the request
+      console.error('Object Store Request failed', event);
+      reject();
+    };
+
+    objectStoreRequest.onsuccess = () => {
+      resolve();
+    };
+  });
+};
+
+const getAndIncrementCount = async () => {
+  const count = await getCount();
+  await incrementCount(count);
+  return count;
+};

--- a/widgets/sw.js
+++ b/widgets/sw.js
@@ -15,14 +15,19 @@ const defaultTemplate = {
   $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
   version: '1.5',
 };
-let incrementButtonClickCount = 0;
-const defaultData = () => {
-  return { count: incrementButtonClickCount++ };
+
+importScripts('counter.js');
+
+const defaultData = async () => {
+  // get the stored count
+  const count = await getAndIncrementCount();
+  return { count };
 };
-const defaultPayload = () => {
+
+const defaultPayload = async () => {
   return {
     template: JSON.stringify(defaultTemplate),
-    data: JSON.stringify(defaultData()),
+    data: JSON.stringify(await defaultData()),
   };
 };
 
@@ -31,6 +36,8 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('install', (event) => {
+  // cach counter script for offline use
+  event.waitUntil(caches.open("v1").then((cache) => cache.add("/pwa/widgets/counter.js")));
   self.skipWaiting();
 });
 
@@ -49,11 +56,11 @@ const incrementWidgetclick = async () => {
   });
 };
 
-self.addEventListener('widgetclick', (event) => {
+self.addEventListener('widgetclick', async (event) => {
   if (event.action === 'widget-install') {
-    updateByTag('max_ac', defaultPayload());
+    event.waitUntil(updateByTag('max_ac', await defaultPayload()));
   } else if (event.action === defaultActionVerb) {
-    updateByTag('max_ac', defaultPayload());
+    event.waitUntil(updateByTag('max_ac', await defaultPayload()));
   }
 
   event.waitUntil(console.log(event));


### PR DESCRIPTION
Adding this change to remember the widget client event across service worker instances. Whenever the service worker restarts, the counter is set to `0` and is confusing while testing widget client events.

This PR adds an indexedDB storage to store and retrieve the counter.