### PR TITLE
Fix event.waitUntil call

### DIFF
--- a/widgets/sw.js
+++ b/widgets/sw.js
@@ -56,11 +56,11 @@ const incrementWidgetclick = async () => {
   });
 };
 
-self.addEventListener('widgetclick', async (event) => {
+self.addEventListener('widgetclick', (event) => {
   if (event.action === 'widget-install') {
-    event.waitUntil(updateByTag('max_ac', await defaultPayload()));
+    event.waitUntil(updateDefaultWidget());
   } else if (event.action === defaultActionVerb) {
-    event.waitUntil(updateByTag('max_ac', await defaultPayload()));
+    event.waitUntil(updateDefaultWidget());
   }
 
   event.waitUntil(console.log(event));
@@ -171,6 +171,10 @@ const updateByInstanceId = async (instanceId, payload) => {
     console.log(error);
     showResult(action, `failed.`);
   }
+};
+
+const updateDefaultWidget = async () => {
+  await updateByTag('max_ac', await defaultPayload());
 };
 
 self.onmessage = (event) => {


### PR DESCRIPTION
Issue: The function `event.waitUntil()` won't wait for the function to complete if the `widgetclick` hander is `async`. This occurs if the browser is shutting down and the service worker will shut down while running the `widgetclick` hander. The `UpdateWidget` function will not be called and the `Max_AC` widget's "Increment" button's click will not work if the browser is not running

Solution: Removed the `async` handler and added another method to `UpdateWidget()` using `async` function. To verify this, the `Max_AC` widget's "Increment" button's click should work event if the browser is not running.