### PR TITLE
Add 'widget-resume' action for 'widgetclick' event handler

### DIFF
--- a/widgets/sw.js
+++ b/widgets/sw.js
@@ -59,6 +59,8 @@ const incrementWidgetclick = async () => {
 self.addEventListener('widgetclick', (event) => {
   if (event.action === 'widget-install') {
     event.waitUntil(updateDefaultWidget());
+  } else if (event.action === 'refresh') {
+    event.waitUntil(updateDefaultWidget());
   } else if (event.action === defaultActionVerb) {
     event.waitUntil(updateDefaultWidget());
   }

--- a/widgets/sw.js
+++ b/widgets/sw.js
@@ -56,11 +56,11 @@ const incrementWidgetclick = async () => {
   });
 };
 
-self.addEventListener('widgetclick', async (event) => {
+self.addEventListener('widgetclick', (event) => {
   if (event.action === 'widget-install') {
-    event.waitUntil(updateByTag('max_ac', await defaultPayload()));
+    event.waitUntil(updateDefaultWidget());
   } else if (event.action === defaultActionVerb) {
-    event.waitUntil(updateByTag('max_ac', await defaultPayload()));
+    event.waitUntil(updateDefaultWidget());
   }
 
   event.waitUntil(console.log(event));
@@ -171,6 +171,10 @@ const updateByInstanceId = async (instanceId, payload) => {
     console.log(error);
     showResult(action, `failed.`);
   }
+};
+
+const updateDefaultWidget = async () => {
+  await updateByTag('max_ac', await defaultPayload());
 };
 
 self.onmessage = (event) => {

--- a/widgets/sw.js
+++ b/widgets/sw.js
@@ -59,7 +59,7 @@ const incrementWidgetclick = async () => {
 self.addEventListener('widgetclick', (event) => {
   if (event.action === 'widget-install') {
     event.waitUntil(updateDefaultWidget());
-  } else if (event.action === 'refresh') {
+  } else if (event.action === 'widget-resume') {
     event.waitUntil(updateDefaultWidget());
   } else if (event.action === defaultActionVerb) {
     event.waitUntil(updateDefaultWidget());


### PR DESCRIPTION
The `widget-resume` action is mentioned in https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/PWAWidgets/README.md#widget-resume. It will be received when the widget host activate the PWA when the Widget instance becomes visible to the user.